### PR TITLE
Add source/lib/curl-build-mingw32 to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 obj/*
 electron-shared
 electron-shared.exe
+
+source/lib/curl-build-mingw32/*


### PR DESCRIPTION
Running make generates a ton of changes(2000+) in source/lib/curl-build-mingw32.  This should ignore them.